### PR TITLE
Eliminate Rewire

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react": "^0.12.2",
     "react-router": "^0.12.4",
     "reflux": "^0.2.7",
-    "rewire": "^2.3.1",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.7.0"
   }


### PR DESCRIPTION
It seems that jest is already overriding require and mocking out
dependencies automatically.
