### PR TITLE
Eliminate Relative Paths in Tests

### DIFF
--- a/__tests__/Hello.js
+++ b/__tests__/Hello.js
@@ -1,7 +1,7 @@
-jest.dontMock('../app/components/Hello');
+jest.dontMock('app/components/Hello');
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
-var Hello = require('../app/components/Hello');
+var Hello = require('app/components/Hello');
 
 describe('Hello', function () {
   it('should render <h1>Hello</h1>', function () {

--- a/__tests__/sum-test.js
+++ b/__tests__/sum-test.js
@@ -1,8 +1,8 @@
-jest.dontMock('../app/util/sum');
+jest.dontMock('app/util/sum');
 
 describe('sum', function() {
  it('adds 1 + 2 to equal 3', function() {
-   var sum = require('../app/util/sum');
+   var sum = require('app/util/sum');
    expect(sum(1, 2)).toBe(3);
  });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Couldn't find a Yeoman generator with webpack, react, reflux and react-router.",
   "scripts": {
-    "test": "jest",
+    "test": "NODE_PATH=. jest",
     "serve": "open 'http://localhost:8080/webpack-dev-server/#/'; webpack-dev-server --content-base public/ --inline",
     "watch": "npm run preview; webpack -w",
     "build": "webpack",


### PR DESCRIPTION
Instead of `require('../../../../path/to/module/ugh')` in our tests we can
simply do `require('app/path/to/module/yay')`. This makes organizing tests
into subdirectories easier since module path is relative to project root.
