### PR TITLE
Enable App Module Paths

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,6 @@
 var React = require('react');
 var Router = require('react-router');
-var routes = require('./routes');
+var routes = require('app/routes');
 
 
 Router.run(routes, function (Handler) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = {
   devtool: 'source-map',
   entry: "./app/index.js",
@@ -8,5 +10,8 @@ module.exports = {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
     ]
+  },
+  resolve: {
+    root: path.resolve(__dirname, '.')
   }
 };


### PR DESCRIPTION
It is now possible to `require('app/path/to/module')` instead of
`require('../../../path/to/module')`.
