### PR TITLE
NPM Init Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "description": "Couldn't find a Yeoman generator with webpack, react, reflux and react-router.",
   "scripts": {
-    "serve": "open 'http://localhost:8080/webpack-dev-server/#/'; webpack-dev-server --content-base public/",
-    "watch": "npm run preview; webpack -w",
-    "build": "webpack",
+    "init": "npm install",
+    "serve": "npm run init; open 'http://localhost:8080/webpack-dev-server/#/'; webpack-dev-server --content-base public/",
+    "watch": "npm run init; npm run preview; webpack -w",
+    "build": "npm run init; webpack",
     "preview": "open public/index.html"
   },
   "repository": {


### PR DESCRIPTION
Adds init task in npm scripts. Run init script in all build tasks.

This allows us to get up and running with a single command, without the
need to install anything globally other than node and npm. It even
eliminates the need to execute `npm install`. Just one command:

``` shell
npm run build
```

Or:

``` shell
npm run serve
```

Later, if we wanted to pull dependencies in with bower, we don't need to
instruct developers to go through additional steps. We just install bower
as a dev dependency and update the init script to run `bower install`.
